### PR TITLE
Fix BF targets and softmax

### DIFF
--- a/dataset/graph_generatior.py
+++ b/dataset/graph_generatior.py
@@ -322,8 +322,10 @@ def generate_targets(graph, start, task_type):
     if task_type == task.PARALLEL_ALGORIHTM:
         bfs = bfs_edge_list(graph, start)
         bf = bellman_ford_edge_list(graph, start)
-        bf_dist = mx.array([list(h['distance'].values()) for h in bf])
-        bf_pred = mx.array([list(h['predecessor'].values()) for h in bf])
+
+        sorted_nodes = sorted(bf[0]['distance'].keys()) if bf else []
+        bf_dist = mx.array([[h['distance'][n] for n in sorted_nodes] for h in bf])
+        bf_pred = mx.array([[h['predecessor'][n] for n in sorted_nodes] for h in bf])
         
         # Convert BFS state to one-hot and add termination targets
         bfs_state_one_hot = binary_to_one_hot(bfs)

--- a/model.py
+++ b/model.py
@@ -135,23 +135,21 @@ class decoder(nn.Module):
 
         concatenated_embeddings = mx.concat([source_embeddings, target_embeddings], axis=1)
 
-        edge_scores = self.predesecor_prob(concatenated_embeddings)
-        # edge_scores = (edge_scores - edge_scores.max()).exp()
+        edge_scores = self.predesecor_prob(concatenated_embeddings).squeeze()
 
-        # softmax_denominator = mx.zeros([num_nodes, 1])
+        # Softmax over incoming edges per target node
+        max_scores = mx.full([num_nodes], -1e9)
+        max_scores = max_scores.at[target_idx].maximum(edge_scores)
+        normalized_scores = edge_scores - mx.take(max_scores, target_idx)
+        exp_scores = mx.exp(normalized_scores)
 
-        # softmax_denominator = softmax_denominator.at[target_idx].add(edge_scores)
-        # softmax_denominator = mx.take(softmax_denominator, target_idx, axis=0)
+        denom = mx.zeros([num_nodes])
+        denom = denom.at[target_idx].add(exp_scores)
+        softmax_denom = mx.take(denom, target_idx)
+        edge_prob = exp_scores / (softmax_denom + 1e-16)
 
-        # edge_prob = edge_scores / (softmax_denominator + 1e-16)
-        # edge_prob = mx.take(edge_scores, target_idx, axis=0)
-
-        # predesecor_predictions = mx.zeros([num_nodes, num_nodes])
-        # predesecor_predictions = predesecor_predictions.at[target_idx, source_idx].add(edge_scores.squeeze)
-
-        predesecor_predictions = mx.full([num_nodes, num_nodes], -1e9)
-        predesecor_predictions = predesecor_predictions.at[target_idx, source_idx].multiply(0)
-        predesecor_predictions = predesecor_predictions.at[target_idx, source_idx].add(edge_scores.squeeze())
+        predesecor_predictions = mx.zeros([num_nodes, num_nodes])
+        predesecor_predictions = predesecor_predictions.at[target_idx, source_idx].add(edge_prob)
 
         bfs_state_predictions = self.bfs_state_outputs(node_embeddings)
         bf_distance_predictions = nn.relu(self.bfs_distance_outputs(node_embeddings))


### PR DESCRIPTION
## Summary
- sort Bellman-Ford dictionaries before conversion to arrays
- apply softmax over incoming edges when predicting predecessors

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683f571602948333809486c14bf2befe